### PR TITLE
feat: adds new chart options to management, signal and dashboard

### DIFF
--- a/netbird-dashboard/Chart.yaml
+++ b/netbird-dashboard/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: netbird-dashboard
 description: UI for the NetBird VPN management platform
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "v1.11.0"
 icon: https://avatars.githubusercontent.com/u/100464677
 annotations:

--- a/netbird-dashboard/templates/_helpers.tpl
+++ b/netbird-dashboard/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Overrides container entrypoint based on a flag
+*/}}
+{{- define "netbird-dashboard.disableIPv6" -}}
+{{- if .Values.netbird.disableIPv6 }}
+command: ["/bin/sh", "-c"]
+args:
+- >
+  sed -i 's/listen \[\:\:\]\:80 default_server\;//g' /etc/nginx/http.d/default.conf &&
+  /usr/bin/supervisord -c /etc/supervisord.conf
+{{- end }}
+{{- end }}

--- a/netbird-dashboard/templates/deployment.yaml
+++ b/netbird-dashboard/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- include "netbird-dashboard.disableIPv6" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/netbird-dashboard/values.yaml
+++ b/netbird-dashboard/values.yaml
@@ -29,6 +29,9 @@ netbird:
   ## @param netbird.managementGrpcApiEndpoint
   managementGrpcApiEndpoint: http://localtest.me:8081
 
+  ## @param disableIPv6
+  disableIPv6: true
+
 ## @section Common configuration
 
 ## @descriptionStart

--- a/netbird/Chart.yaml
+++ b/netbird/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: netbird
 description: NetBird VPN management platform
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "0.19.0"
 icon: https://avatars.githubusercontent.com/u/100464677
 annotations:

--- a/netbird/management.tmpl.json
+++ b/netbird/management.tmpl.json
@@ -21,7 +21,7 @@
         "TimeBasedCredentials": false
     },
     "Signal": {
-        "Proto": "https",
+        "Proto": "${NETBIRD_SIGNAL_PROTOCOL}",
         "URI": "${NETBIRD_SIGNAL_URI}",
         "Username": "",
         "Password": null

--- a/netbird/templates/management-deployment.yaml
+++ b/netbird/templates/management-deployment.yaml
@@ -45,6 +45,8 @@ spec:
           env:
             - name: NETBIRD_SIGNAL_URI
               value: {{ .Values.signal.uri }}
+            - name: NETBIRD_SIGNAL_PROTOCOL
+              value: {{ .Values.signal.protocol }}
             - name: NETBIRD_STUN_URI
               value: {{ .Values.stun.uri }}
             - name: NETBIRD_TURN_URI

--- a/netbird/templates/signal-deployment.yaml
+++ b/netbird/templates/signal-deployment.yaml
@@ -33,17 +33,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.signal.image.repository }}:{{ .Values.signal.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.signal.image.pullPolicy }}
-          args: ["--log-level", "{{ .Values.signal.logLevel }}"]
+          args: ["--port", "{{ .Values.signal.service.port }}", "--log-level", "{{ .Values.signal.logLevel }}", "--log-file", "console"]
           ports:
-            - name: grpc
+            - name: {{ .Values.signal.protocol }}
               containerPort: {{ .Values.signal.service.port }}
               protocol: TCP
           livenessProbe:
             tcpSocket:
-              port: grpc
+              port: {{ .Values.signal.protocol }}
           readinessProbe:
             tcpSocket:
-              port: grpc
+              port: {{ .Values.signal.protocol }}
           resources:
             {{- toYaml .Values.signal.resources | nindent 12 }}
           volumeMounts:

--- a/netbird/templates/signal-service.yaml
+++ b/netbird/templates/signal-service.yaml
@@ -8,8 +8,8 @@ spec:
   type: {{ .Values.signal.service.type }}
   ports:
     - port: {{ .Values.signal.service.port }}
-      targetPort: grpc
+      targetPort: {{ .Values.signal.protocol }}
       protocol: TCP
-      name: http
+      name: {{ .Values.signal.protocol }}
   selector:
     {{- include "netbird.signal.selectorLabels" . | nindent 4 }}

--- a/netbird/values.yaml
+++ b/netbird/values.yaml
@@ -9,6 +9,7 @@ auth:
   ## @param auth.authority
   ##
   authority: http://keycloak.localtest.me:9000/realms/helm-charts
+  # authority: https://<tenant-name>.us.auth0.com
 
   device:
     ## @param auth.device.provider
@@ -30,8 +31,8 @@ idp:
   managerType: none
   # clientID:
   # secretKeyRef:
-  #   name: turn-credentials
-  #   key: password
+  #   name: idp-credentials
+  #   key: secretkey
   # grantType:
 
   # Auth0
@@ -252,6 +253,10 @@ signal:
   ## @param signal.uri
   ##
   uri: example.com:10000
+
+  ## @param signal.protocol grpc, http, https
+  ##
+  protocol: grpc
 
   ## @param signal.replicaCount
   ##


### PR DESCRIPTION
This PR aims to add a few new options to configure netbird components like:
- signal protocol option between grpc, http and https
- an option to change the signal port
- changes signal log output to stdout instead of a file
- adds a workaround to disable ipv6 directive (listen) from nginx (dashboard) conf

That workaround isn't the best approach, definitely, but I did it just for the sake of simplicity and to make the chart run.

A better approach, for example, would be having a configmap with nginx's default.conf snippet templatized to handle that specific ipv6 param (and maybe other params) properly, through the chart itself.