### PR TITLE
feat: log netbird management to console

### DIFF
--- a/netbird/templates/management-deployment.yaml
+++ b/netbird/templates/management-deployment.yaml
@@ -141,6 +141,8 @@ spec:
           args:
             - --log-level
             - info
+            - --log-file
+            - console
             - --dns-domain
             - {{ .Values.management.dnsDomain }}
           ports:


### PR DESCRIPTION
Set netbird-management to log to the console, otherwise messages are not displayed when using `kubectl logs`.