### PR TITLE
Feat: Add values for redirect_uris and netbird token source

### DIFF
--- a/netbird-dashboard/templates/deployment.yaml
+++ b/netbird-dashboard/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
               value: {{ .Values.auth.silent_redirect_uri }}
             {{- if .Values.netbird.token_source }}
             - name: NETBIRD_TOKEN_SOURCE
-              value: {{ .Values.netbird_token_source }}
+              value: {{ .Values.netbird.token_source }}
             {{- end }}
           ports:
             - name: http

--- a/netbird-dashboard/templates/deployment.yaml
+++ b/netbird-dashboard/templates/deployment.yaml
@@ -51,6 +51,14 @@ spec:
               value: {{ .Values.netbird.managementGrpcApiEndpoint }}
             - name: NGINX_SSL_PORT
               value: "443"
+            - name: AUTH_REDIRECT_URI
+              value: {{ .Values.auth.redirect_uri }}
+            - name: AUTH_SILENT_REDIRECT_URI
+              value: {{ .Values.auth.silent_redirect_uri }}
+            {{- if .Values.netbird.token_source }}
+            - name: NETBIRD_TOKEN_SOURCE
+              value: {{ .Values.netbird_token_source }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/netbird-dashboard/values.yaml
+++ b/netbird-dashboard/values.yaml
@@ -20,6 +20,12 @@ auth:
   ## @param auth.userIDClaim
   userIDClaim: sub
 
+  ## @param auth.redirect_uri
+  redirect_uri: /auth
+
+  ## @param auth.silent_redirect_uri
+  silent_redirect_uri: /silent-auth
+
 ## @section NetBird configuration
 
 netbird:
@@ -31,6 +37,10 @@ netbird:
 
   ## @param netbird.disableIPv6
   disableIPv6: true
+
+  ## @param netbird.token_source
+  ## In some setups, the id_token might be used instead of the access_token. In that case, set token_source to idToken.
+  token_source: ""
 
 ## @section Common configuration
 
@@ -86,16 +96,13 @@ defaultLabels: {}
 ## ref:
 ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext
-podSecurityContext:
-  {}
-  # fsGroup: 2000
+podSecurityContext: {} # fsGroup: 2000
 
 ## Configure Container Security Context
 ## ref:
 ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param securityContext
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -118,8 +125,7 @@ ingress:
   className: ""
 
   ## @param ingress.annotations
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
 
@@ -140,8 +146,7 @@ ingress:
   #      - chart-example.local
 
 ## @param resources
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a
   # conscious choice for the user. This also increases chances charts run on
   # environments with little resources, such as Minikube. If you do want to
@@ -166,7 +171,6 @@ autoscaling:
 
   ## @param autoscaling.targetCPUUtilizationPercentage
   targetCPUUtilizationPercentage: 80
-
   ## @param autoscaling.targetCPUUtilizationPercentage
   # targetMemoryUtilizationPercentage: 80
 


### PR DESCRIPTION
I wish there was a comprehensive list of environment variables that were available to configure netbird services, however [the documentation](https://docs.netbird.io/selfhosted/environment-variables) is rather lacking.

Those variables can be found [here](https://github.com/netbirdio/netbird/blob/main/infrastructure_files/docker-compose.yml.tmpl#L24), but from what I understand:

`AUTH_REDIRECT_URIS`: Not sure what is the difference between the silent and normal onces, but URIs to redirect to on successful login.

`NETBIRD_TOKEN_SOURCE`:  In the setup with Authelia, it is required to set `id_token` to be the token to use instead of `access_token`, as documented in the [authelia integration with netbird doc](https://www.authelia.com/integration/openid-connect/clients/netbird/#netbird-dashboard).

EDIT:
Removed token secret, as the dashboard is a web application, hence it should not login against the IdP using a confidential client.

editted `NETBIRD_TOKEN_SOURCE` description, as I understood why it is required.

