### PR TITLE
feat(coturn): update to 4.10.0-r1

### DIFF
--- a/coturn/Chart.yaml
+++ b/coturn/Chart.yaml
@@ -3,12 +3,12 @@ apiVersion: v2
 name: coturn
 description: Coturn TURN server
 type: application
-version: 1.0.4
-appVersion: "4.7.0-r2"
+version: 1.0.5
+appVersion: "4.10.0-r1"
 annotations:
   artifacthub.io/category: networking
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "true"
   artifacthub.io/changes: |
     - kind: changed
-      description: Update to 4.7.0-r2
+      description: Update to 4.10.0-r1

--- a/coturn/turnserver.conf
+++ b/coturn/turnserver.conf
@@ -157,6 +157,11 @@ tls-listening-port=5349
 min-port=49152
 max-port=65535
 
+# Socket buffer size (in bytes).
+# (default value is 2097152 which is 2MB)
+#
+#sock-buf-size=2097152
+
 # Uncomment to run TURN server in 'normal' 'moderate' verbose mode.
 # By default the verbose mode is off.
 #verbose
@@ -700,11 +705,11 @@ realm=example.org
 #
 #proc-group=<group-name>
 
-# Turn OFF the CLI support.
-# By default it is always ON.
+# Turn on CLI support.
+# By default it is always OFF.
 # See also options cli-ip and cli-port.
 #
-#no-cli
+#cli
 
 #Local system IP address to be used for CLI server endpoint. Default value
 # is 127.0.0.1.
@@ -765,14 +770,16 @@ cli-password=CHANGE_ME
 #
 #cli-max-output-sessions
 
-# Set network engine type for the process (for internal purposes).
+# Network engine type (for internal purposes).
+# Only one engine is available: NEV_UDP_SOCKET_PER_THREAD.
+# This option is ignored and kept for backwards compatibility only.
 #
-#ne=[1|2|3]
+#ne=3
 
-# Do not allow an TLS/DTLS version of protocol
+# Enable older TLS/DTLS protocol versions (disabled by default; default minimum is TLSv1.2)
 #
-#no-tlsv1
-#no-tlsv1_1
+#tlsv1
+#tlsv1_1
 #no-tlsv1_2
 
 # Enable RFC5780 (NAT behavior discovery).
@@ -796,3 +803,12 @@ cli-password=CHANGE_ME
 # binding responses.
 #
 # stun-backward-compatibility
+
+# Include descriptive reason strings in STUN/TURN error responses.
+# By default, only the standard reason phrase for the error code is sent
+# (e.g. "Unauthorized", "Forbidden"). Enabling this option adds detailed
+# error descriptions (e.g. "User name is too long", "Wrong Transport Field")
+# which may aid debugging but can also expose internal server information.
+# Disabled by default.
+#
+# include-reason-string


### PR DESCRIPTION
- cli is off by default (following change from upstream).
- TLS 1.0 and TLS 1.1 are disabled by default (again, following change from upstream).